### PR TITLE
Add ingress-nginx controller to snd1

### DIFF
--- a/core/ingress-nginx/kustomization.yaml
+++ b/core/ingress-nginx/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-config
+resources:
+  - repository.yaml
+  - release.yaml

--- a/core/ingress-nginx/release.yaml
+++ b/core/ingress-nginx/release.yaml
@@ -1,0 +1,62 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: release-ingress-nginx
+  namespace: flux-config
+spec:
+  chart:
+    spec:
+      chart: ingress-nginx
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: repository-ingress-nginx
+  install:
+    createNamespace: true
+  interval: 5m0s
+  releaseName: ingress-nginx
+  targetNamespace: ingress-nginx
+  values:
+    defaultBackend:
+      nodeSelector:
+        kubernetes.io/os: "linux"
+    controller:
+      nginxplus: false
+      ingressClassResource:
+        name: nginx-oss
+      ingressClass: nginx-oss
+      allowSnippetAnnotations: true
+      service:
+        enabled: true
+        type: LoadBalancer
+        annotations:
+          service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+          service.beta.kubernetes.io/azure-pls-create: "true"
+          service.beta.kubernetes.io/azure-pls-name: "aks-loadbalancer-pls"
+        internal:
+          enabled: true
+          type: LoadBalancer
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Equal"
+          value: "true"
+          effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.azure.com/mode
+                operator: In
+                values:
+                  - 'system'
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      config:
+        entries:
+          http2: "True"
+        annotations-risk-level: Critical
+      podDisruptionBudget:
+        enabled: true
+        annotations: {}
+      enableSnippets: true

--- a/core/ingress-nginx/repository.yaml
+++ b/core/ingress-nginx/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: repository-ingress-nginx
+  namespace: flux-config
+spec:
+  interval: 24h
+  url: https://helm.nginx.com/stable

--- a/infra/snd/01/ingress-nginx-values.yaml
+++ b/infra/snd/01/ingress-nginx-values.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ingress-nginx
+  namespace: flux-config
+spec:
+  chart:
+    spec:
+      version: 4.12.1
+  values:
+    controller:
+      service:
+        annotations:
+          service.beta.kubernetes.io/azure-pls-visibility: "${SUBSCRIPTION_ID}"
+          service.beta.kubernetes.io/azure-pls-auto-approval: "${SUBSCRIPTION_ID}"
+          service.beta.kubernetes.io/azure-load-balancer-internal-subnet: "${LOAD_BALANCER_SUBNET}"
+      image:
+        repository: "${SHARED_CONTAINER_REGISTRY}.azurecr.io/image/ingress-nginx"
+        tag: 1.12.1
+      replicaCount: 3
+      podDisruptionBudget:
+        minAvailable: 2

--- a/infra/snd/01/kustomization.yaml
+++ b/infra/snd/01/kustomization.yaml
@@ -3,11 +3,16 @@ kind: Kustomization
 resources:
   - ../base
   - ../../../core/calico
+  - ../../../core/ingress-nginx
 patches:
   - path: nginx-ingress-values.yaml
     target:
       kind: HelmRelease
       name: release-nginx-ingress
+  - path: ingress-nginx-values.yaml
+    target:
+      kind: HelmRelease
+      name: release-ingress-nginx
   - path: app-config-service-values.yaml
     target:
       name: release-app-config-service


### PR DESCRIPTION
# **What this PR does / why we need it**:
Adds ingress-nginx (oss) to ADP SND1 AKS Cluster

# **Special notes for your reviewer**
Temporarily added `- ../../../../core/ingress-nginx` to the SND1 kustomization. Once we have validated this change we will need to move this to the base in the respective environments. 

# Testing
*Any relevant testing information and pipeline runs.*
